### PR TITLE
fix(reports): include inactive users in survey pending list

### DIFF
--- a/Backend/SurveyApp.Application/Services/ReportService.cs
+++ b/Backend/SurveyApp.Application/Services/ReportService.cs
@@ -26,7 +26,7 @@ public class ReportService : IReportService
         var respondedUserIds = responses.Select(r => r.UserId).ToHashSet();
         var pendingUserIds = assignedUserIds.Except(respondedUserIds).ToList();
 
-        var allUsers = await _uow.Users.GetAllActiveUsersAsync();
+        var allUsers = await _uow.Users.GetAllAsync();
         var pendingUsers = allUsers.Where(u => pendingUserIds.Contains(u.Id))
             .Select(u => new UserDto(u.Id, u.Email, u.FullName, u.Role, u.IsActive)).ToList();
 


### PR DESCRIPTION
Closes #8

## Change
`ReportService.GetSurveyReportAsync` — replaced `GetAllActiveUsersAsync()`
with `GetAllAsync()` when building the pending users list.

## Why
A deactivated user assigned to a survey still counts toward `TotalPending`
(correct, since the count comes from raw ID set subtraction), but was absent
from `PendingUsers` (wrong, because the active-only query excluded them).
This produced mismatched totals and a visually incomplete pending tab.