### PR TITLE
fix: move mobile-topbar display rules to global.css

### DIFF
--- a/Frontend/survey-app/src/components/admin/AdminLayout.tsx
+++ b/Frontend/survey-app/src/components/admin/AdminLayout.tsx
@@ -127,14 +127,6 @@ export default function AdminLayout() {
           </div>
         </div>
 
-        <style>{`
-          .mobile-topbar { display: none; }
-          @media (max-width: 768px) {
-            .mobile-topbar { display: flex !important; }
-            .mob-overlay   { display: block !important; }
-          }
-        `}</style>
-
         <Outlet />
       </main>
     </div>

--- a/Frontend/survey-app/src/styles/global.css
+++ b/Frontend/survey-app/src/styles/global.css
@@ -530,7 +530,10 @@ body {
   .admin-main { margin-left: 0 !important; }
 
   /* Mobile overlay */
+  .mobile-topbar { display: none; }
+@media (max-width: 768px) {
   .mobile-topbar { display: flex !important; }
+}
   .mob-overlay   { display: block !important; z-index: 199; }
   
   /*


### PR DESCRIPTION
Closes #17 